### PR TITLE
Update ili2gpkg version to 3.12.3

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
@@ -49,7 +49,7 @@ class GpkgFactory(DbFactory):
 
         :return: str ili2gpkg version.
         """
-        return '3.11.3'
+        return '3.12.3'
 
     def get_tool_url(self):
         """Returns download url of ili2gpkg.


### PR DESCRIPTION
This ili2gpkg version will be used in a FOSS4G workshop along with Model Baker.